### PR TITLE
prefix variables with module name

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 μg Project Team
+# Copyright (c) 2015 μg Project Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,22 +19,22 @@ LOCAL_MODULE := GmsCore
 LOCAL_MODULE_TAGS := optional
 LOCAL_PACKAGE_NAME := GmsCore
 
-module_root  := $(LOCAL_PATH)
-module_dir   := play-services-core
-module_out   := $(OUT_DIR)/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
-module_build := $(module_root)/$(module_dir)/build
-module_apk   := build/outputs/apk/play-services-core-release-unsigned.apk
+gmscore_root  := $(LOCAL_PATH)
+gmscore_dir   := play-services-core
+gmscore_out   := $(OUT_DIR)/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
+gmscore_build := $(gmscore_root)/$(gmscore_dir)/build
+gmscore_apk   := build/outputs/apk/play-services-core-release-unsigned.apk
 
-$(module_root)/$(module_dir)/$(module_apk):
-	rm -Rf $(module_build)
-	mkdir -p $(module_out)
-	ln -s $(module_out) $(module_build)
-	echo "sdk.dir=$(ANDROID_HOME)" > $(module_root)/local.properties
-	cd $(module_root) && git submodule update --recursive --init
-	cd $(module_root)/$(module_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
+$(gmscore_root)/$(gmscore_dir)/$(gmscore_apk):
+	rm -Rf $(gmscore_build)
+	mkdir -p $(gmscore_out)
+	ln -s $(gmscore_out) $(gmscore_build)
+	echo "sdk.dir=$(ANDROID_HOME)" > $(gmscore_root)/local.properties
+	cd $(gmscore_root) && git submodule update --recursive --init
+	cd $(gmscore_root)/$(gmscore_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform
-LOCAL_SRC_FILES := $(module_dir)/$(module_apk)
+LOCAL_SRC_FILES := $(gmscore_dir)/$(gmscore_apk)
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 


### PR DESCRIPTION
Prefix variables in Android.mk with module name to avoid conflicts with other make files in the android source tree.