### PR TITLE
McsService does not back off on Failure (Untested Patch included)

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -377,11 +377,9 @@ public class McsService extends Service implements Handler.Callback {
             sslSocket.close();
         } catch (Exception ignored) {
         }
-        if (currentDelay == 0) {
-            sendBroadcast(new Intent("org.microg.gms.gcm.RECONNECT"), "org.microg.gms.STATUS_BROADCAST");
-        } else {
-            scheduleReconnect(this);
-        }
+        
+        scheduleReconnect(this);
+        
         alarmManager.cancel(heartbeatIntent);
         if (wakeLock != null) {
             wakeLock.release();


### PR DESCRIPTION
Hi, I had some intermittent network issues and noticed my phone would not deep sleep.

I think the McsService does not back off if there is an Exception in the `connect()` method.
The `currentDelay` field is checked, but it is always `0` in that codepath so that a RECONNECT Intent is fired and it loops.

I think it should be enough to use the `getCurrentDelay()` method instead of accessing the field directly.

Here some logs:
````

10-23 16:24:51.769 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.769 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.772 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.775 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.775 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.776 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.776 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.778 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.781 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.781 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.782 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.782 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.785 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.788 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.789 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.789 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.789 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.792 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.796 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.796 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.797 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.797 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.800 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.803 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.803 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.804 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.804 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.806 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.810 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.811 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.811 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.811 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.814 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.818 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.818 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.819 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.819 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.822 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.826 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.826 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.827 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.827 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.829 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.832 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.833 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.833 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
10-23 16:24:51.833 21174 23719 D GmsGcmMcsSvc: Teardown initiated, reason: java.net.UnknownHostException: Unable to resolve host "mtalk.google.com": No address associated with hostname
10-23 16:24:51.836 21174 21174 D GmsGcmTrigger: Not connected to GCM but should be, asking the service to start up
10-23 16:24:51.839 21174 23719 D GmsGcmMcsSvc: Connect initiated, reason: Intent { act=org.microg.gms.gcm.RECONNECT flg=0x10 cmp=com.google.android.gms/org.microg.gms.gcm.TriggerReceiver }
10-23 16:24:51.840 21174 23719 D GmsGcmMcsSvc: Starting MCS connection...
10-23 16:24:51.840 21174 23719 W GmsGcmMcsSvc: Exception while connecting!
```