### PR TITLE
Bugfix for fixing AbstractMethodError in Marshmallow

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/maps/ContextContainer.java
+++ b/play-services-core/src/main/java/org/microg/gms/maps/ContextContainer.java
@@ -101,6 +101,10 @@ public class ContextContainer extends Context {
         return original.getPackageName();
     }
 
+    public String getOpPackageName() {
+        return original.getPackageName();
+    }
+
     @Override
     public ApplicationInfo getApplicationInfo() {
         return original.getApplicationInfo();


### PR DESCRIPTION
Using play-services in Marshmallow gives an `AbstractMethodError` because InputMethodManager calls `getOpPackageName()` instead of `getPackageName()` on Context. See line 1179 in https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/java/android/view/inputmethod/InputMethodManager.java vs https://github.com/android/platform_frameworks_base/blob/marshmallow-release/core/java/android/view/inputmethod/InputMethodManager.java

Since ContextContainer implements Context but does not fill in this method, errors happen. This small patch will fix the error (tested on cm13).

Also fixes moosd/Needle#1