### PR TITLE
Fixes for connectivity issues

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsInputStream.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsInputStream.java
@@ -77,6 +77,7 @@ public class McsInputStream extends Thread {
                     mainHandler.dispatchMessage(mainHandler.obtainMessage(MSG_INPUT, msg));
                 } else {
                     mainHandler.dispatchMessage(mainHandler.obtainMessage(MSG_TEARDOWN, "null message"));
+                    break; // if input is empty, do not continue looping
                 }
             }
         } catch (IOException e) {

--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -323,7 +323,7 @@ public class McsService extends Service implements Handler.Callback {
 
     private void sendOutputStream(int what, Object obj) {
         McsOutputStream os = outputStream;
-        if (os != null) {
+        if (os != null && os.isAlive()) {
             Handler outputHandler = os.getHandler();
             if (outputHandler != null)
                 outputHandler.sendMessage(outputHandler.obtainMessage(what, obj));


### PR DESCRIPTION
This is an attempt at fixing two issues with tear downs because of connectivity issues:

* When a connect failed (e.g. due to bad network connectivity) I got errors because messages were sent to a dead handler thread. This is because tear downs try to shut down the output stream that has not been started yet. I've added a check if the output handler thread is alive in order to avoid this.
* This morning, my log was filled with messages from `McsInputStream` because `read()` on the input stream returned `-1` and it sent tear down messages to the main handler in a busy loop. I don't know why the main handler did not interrupt the input stream when the first tear down occurred. The tear down messages were handled, triggered the first error, scheduled reconnect attempts with the maximum interval (600s) but probably did not interrupt the input thread as `inputStream` in the `McsService` was already `null`. My fix now avoids this busy loop by directly terminating the input stream thread after triggering the tear down. This should be safe as the main handler would interrupt it anyway (which has no effect if the thread is not alive).

I don't know if this really fixes both issues, for the first one I'm relatively sure, concerning the second one I've no idea what caused it and therefore this fix is mainly treating the symptoms I've seen.