### PR TITLE
Android Marshmallow Patch

### DIFF
--- a/patches/android_frameworks_base-M.patch
+++ b/patches/android_frameworks_base-M.patch
@@ -1,52 +1,21 @@
-diff --git a/core/java/android/content/pm/PackageParser.java b/core/java/android/content/pm/PackageParser.java
-index 99bd390..2ea7722 100644
---- a/core/java/android/content/pm/PackageParser.java
-+++ b/core/java/android/content/pm/PackageParser.java
-@@ -578,10 +578,22 @@ public class PackageParser {
-             }
-         }
-         if ((flags&PackageManager.GET_SIGNATURES) != 0) {
--           int N = (p.mSignatures != null) ? p.mSignatures.length : 0;
--           if (N > 0) {
--                pi.signatures = new Signature[N];
--                System.arraycopy(p.mSignatures, 0, pi.signatures, 0, N);
-+               boolean handledFakeSignature = false;
-+               try {
-+                       if (p.requestedPermissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE") && p.mAppMetaData != null && 
-p.mAppMetaData.get("fake-signature") instanceof String) {
-+                       pi.signatures = new Signature[] {new Signature(p.mAppMetaData.getString("fake-signature"))};
-+                       handledFakeSignature = true;
-+                       }
-+               } catch (Throwable t) {
-+                       //We should never die because of any failures, this is system code!
-+                       Log.w("PackageParser.FAKE_PACKAGE_SIGNATURE", t);
-+               }
-+               if (!handledFakeSignature) {
-+                       int N = (p.mSignatures != null) ? p.mSignatures.length : 0;
-+                       if (N > 0) {
-+                               pi.signatures = new Signature[N];
-+                               System.arraycopy(p.mSignatures, 0, pi.signatures, 0, N);
-+                       }
-             }
-         }
-         return pi;
 diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
-index 08bccc1..93afc86 100644
+index 08bccc1..45b0094 100644
 --- a/core/res/AndroidManifest.xml
 +++ b/core/res/AndroidManifest.xml
-@@ -1623,6 +1623,12 @@
+@@ -1622,6 +1622,13 @@
+         android:label="@string/permlab_getPackageSize"
          android:description="@string/permdesc_getPackageSize"
          android:protectionLevel="normal" />
- 
++    
++    <!-- @hide Allows an application to change the package signature as
++         seen by applications -->
 +    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
-+       android:permissionGroup="android.permission-group.SYSTEM_TOOLS"
-+       android:protectionLevel="dangerous"
-+       android:label="@string/permlab_fakePackageSignature"
-+       android:description="@string/permdesc_fakePackageSignature" />
-+
++        android:protectionLevel="dangerous"
++        android:label="@string/permlab_fakePackageSignature"
++        android:description="@string/permdesc_fakePackageSignature" />
+ 
      <!-- @deprecated No longer useful, see
           {@link android.content.pm.PackageManager#addPackageToPreferred}
-          for details. -->
 diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
 index 6c96f84..c391f30 100644
 --- a/core/res/res/values/config.xml
@@ -61,16 +30,50 @@ index 6c96f84..c391f30 100644
  
      <!-- This string array can be overriden to enable test location providers initially. -->
 diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
-index 8a9b9cf..d4ad231 100644
+index 8a9b9cf..cd7ec0d 100644
 --- a/core/res/res/values/strings.xml
 +++ b/core/res/res/values/strings.xml
-@@ -763,6 +763,9 @@
-     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
-     <string name="permdesc_getPackageSize">Allows the app to retrieve its code, data, and cache sizes</string>
+@@ -615,6 +615,11 @@
  
-+    <string name="permlab_fakePackageSignature">mimic package signature</string>
-+    <string name="permdesc_fakePackageSignature">Allows the app to use mimic another app\'s package signature.</string>
+     <!--  Permissions -->
+ 
++   <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permlab_fakePackageSignature">Spoof package signature</string>
++    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permdesc_fakePackageSignature">Allows the app to pretend to be a different app. Malicious applications might be able to use this to access private application data. Grant this permission with caution only!</string>
 +
      <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
-     <string name="permlab_writeSettings">modify system settings</string>
+     <string name="permlab_statusBar">disable or modify status bar</string>
      <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+diff --git a/services/core/java/com/android/server/pm/PackageManagerService.java b/services/core/java/com/android/server/pm/PackageManagerService.java
+index c1d091b..8195e32 100644
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -2653,8 +2653,27 @@ public class PackageManagerService extends IPackageManager.Stub {
+         final Set<String> permissions = permissionsState.getPermissions(userId);
+         final PackageUserState state = ps.readUserState(userId);
+ 
+-        return PackageParser.generatePackageInfo(p, gids, flags,
+-                ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId);
++        return mayFakeSignature(p, PackageParser.generatePackageInfo(p, gids, flags,
++                ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId),
++                permissions);
++    }
++
++    private PackageInfo mayFakeSignature(PackageParser.Package p, PackageInfo pi,
++            Set<String> permissions) {
++        try {
++            if (permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")
++                    && p.applicationInfo.targetSdkVersion > Build.VERSION_CODES.LOLLIPOP_MR1
++                    && p.mAppMetaData != null) {
++                String sig = p.mAppMetaData.getString("fake-signature");
++                if (sig != null) {
++                    pi.signatures = new Signature[] {new Signature(sig)};
++                }
++            }
++        } catch (Throwable t) {
++            // We should never die because of any failures, this is system code!
++            Log.w("PackageManagerService.FAKE_PACKAGE_SIGNATURE", t);
++        }
++        return pi;
+     }

--- a/patches/android_frameworks_base-M.patch
+++ b/patches/android_frameworks_base-M.patch
@@ -1,0 +1,76 @@
+diff --git a/core/java/android/content/pm/PackageParser.java b/core/java/android/content/pm/PackageParser.java
+index 99bd390..2ea7722 100644
+--- a/core/java/android/content/pm/PackageParser.java
++++ b/core/java/android/content/pm/PackageParser.java
+@@ -578,10 +578,22 @@ public class PackageParser {
+             }
+         }
+         if ((flags&PackageManager.GET_SIGNATURES) != 0) {
+-           int N = (p.mSignatures != null) ? p.mSignatures.length : 0;
+-           if (N > 0) {
+-                pi.signatures = new Signature[N];
+-                System.arraycopy(p.mSignatures, 0, pi.signatures, 0, N);
++               boolean handledFakeSignature = false;
++               try {
++                       if (p.requestedPermissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE") && p.mAppMetaData != null && 
+p.mAppMetaData.get("fake-signature") instanceof String) {
++                       pi.signatures = new Signature[] {new Signature(p.mAppMetaData.getString("fake-signature"))};
++                       handledFakeSignature = true;
++                       }
++               } catch (Throwable t) {
++                       //We should never die because of any failures, this is system code!
++                       Log.w("PackageParser.FAKE_PACKAGE_SIGNATURE", t);
++               }
++               if (!handledFakeSignature) {
++                       int N = (p.mSignatures != null) ? p.mSignatures.length : 0;
++                       if (N > 0) {
++                               pi.signatures = new Signature[N];
++                               System.arraycopy(p.mSignatures, 0, pi.signatures, 0, N);
++                       }
+             }
+         }
+         return pi;
+diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
+index 08bccc1..93afc86 100644
+--- a/core/res/AndroidManifest.xml
++++ b/core/res/AndroidManifest.xml
+@@ -1623,6 +1623,12 @@
+         android:description="@string/permdesc_getPackageSize"
+         android:protectionLevel="normal" />
+ 
++    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
++       android:permissionGroup="android.permission-group.SYSTEM_TOOLS"
++       android:protectionLevel="dangerous"
++       android:label="@string/permlab_fakePackageSignature"
++       android:description="@string/permdesc_fakePackageSignature" />
++
+     <!-- @deprecated No longer useful, see
+          {@link android.content.pm.PackageManager#addPackageToPreferred}
+          for details. -->
+diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
+index 6c96f84..c391f30 100644
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -1176,6 +1176,8 @@
+     <string-array name="config_locationProviderPackageNames" translatable="false">
+         <!-- The standard AOSP fused location provider -->
+         <item>com.android.location.fused</item>
++        <!-- The (faked) microg fused location provider -->
++        <item>com.google.android.gms</item>
+     </string-array>
+ 
+     <!-- This string array can be overriden to enable test location providers initially. -->
+diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
+index 8a9b9cf..d4ad231 100644
+--- a/core/res/res/values/strings.xml
++++ b/core/res/res/values/strings.xml
+@@ -763,6 +763,9 @@
+     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permdesc_getPackageSize">Allows the app to retrieve its code, data, and cache sizes</string>
+ 
++    <string name="permlab_fakePackageSignature">mimic package signature</string>
++    <string name="permdesc_fakePackageSignature">Allows the app to use mimic another app\'s package signature.</string>
++
+     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permlab_writeSettings">modify system settings</string>
+     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->


### PR DESCRIPTION
This commit adds a patch for Android Marshmallow including:

1. Signature Spoofing
2. Location Provider Support

Before building a patched Android Marshmallow system, it is required to execute `make update-api` in the root directory.