### PR TITLE
Fix small typo in strings

### DIFF
--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -99,7 +99,7 @@ This can take a couple of minutes."</string>
 
     <string name="self_check_cat_system">System</string>
     <string name="self_check_name_battery_optimizations">Battery optimizations ignored:</string>
-    <string name="self_check_resolution_battery_optimizations">Touch here to disable battery optimizations. Not doing this may result in misbehaving applications</string>
+    <string name="self_check_resolution_battery_optimizations">Touch here to disable battery optimizations. Not doing this may result in misbehaving applications.</string>
 
     <string name="lacking_permission_toast">microG Services Core: Lacking permission to <xliff:g example="have full network acccess">%1$s</xliff:g></string>
 


### PR DESCRIPTION
I’m currently working on the french translation and just spotted this.