### PR TITLE
Complete removal of safe-parcel subproject

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,3 @@
-include ':safe-parcel'
-
 include ':wearable-lib'
 
 include ':unifiednlp-api'


### PR DESCRIPTION
Remove safe-parcel gradle sub-project. The git submodule was
already removed by 07ff44e3c6906d65805e01c566e748b817fba0fd.