### PR TITLE
Check if callback is non null. Fixes #340 #364.

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/maps/GoogleMapImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/maps/GoogleMapImpl.java
@@ -545,10 +545,12 @@ public class GoogleMapImpl extends IGoogleMapDelegate.Stub
             @Override
             public void run() {
                 Log.d(TAG, "Announce map loaded");
-                try {
-                    callback.onMapLoaded();
-                } catch (RemoteException e) {
-                    Log.w(TAG, e);
+                if (callback != null) {
+                    try {
+                        callback.onMapLoaded();
+                    } catch (RemoteException e) {
+                        Log.w(TAG, e);
+                    }
                 }
             }
         }, 5000);


### PR DESCRIPTION
Some map apps like uber are crashing when setOnMapLoadedCallback() gets empty callback. So we check it first. 