### PR TITLE
Add youtube music to KNOWN_GOOGLE_PACKAGES

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/common/PackageUtils.java
+++ b/play-services-core/src/main/java/org/microg/gms/common/PackageUtils.java
@@ -53,6 +53,7 @@ public class PackageUtils {
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.travel.onthego", "0cbe08032217d45e61c0bc72f294395ee9ecb5d5");
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.tycho", "01b844184e360686aa98b48eb16e05c76d4a72ad");
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.wearable.app", "a197f9212f2fed64f0ff9c2a4edf24b9c8801c8c");
+        KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.youtube.music", "afb0fed5eeaebdd86f56a97742f4b6b33ef59875");
         KNOWN_GOOGLE_PACKAGES.put("com.google.vr.cyclops", "188c5ca3863fa121216157a5baa80755ceda70ab");
         KNOWN_GOOGLE_PACKAGES.put("com.waze", "35b438fe1bc69d975dc8702dc16ab69ebf65f26f");
     }


### PR DESCRIPTION
This is necessary for youtube music to work correctly. Otherwise, it doesn't get access to the system accounts, and thus refuses to log in.