### PR TITLE
Add patch for Android O (8.0.0_r4)

### DIFF
--- a/patches/android_frameworks_base-O.patch
+++ b/patches/android_frameworks_base-O.patch
@@ -1,0 +1,102 @@
+commit 4e9d677b35b9656c22c922c9abca4107ab95c9b4
+Author: Bernhard Rosenkränzer <bero@lindev.ch>
+Date:   Tue Aug 29 00:34:27 2017 +0200
+
+    Add permission to allow an APK to fake a signature.
+    
+    This is needed by GmsCore (https://microg.org/) to pretend
+    the existence of the official Play Services to applications calling
+    Google APIs.
+    
+    Forward-ported from https://github.com/microg/android_packages_apps_GmsCore/blob/master/patches/android_frameworks_base-N.patch
+    
+    Change-Id: I603fd09200432f7e1bf997072188cdfa6da1594f
+    Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>
+
+diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
+index 794d4f8b78b..b3189077256 100644
+--- a/core/res/AndroidManifest.xml
++++ b/core/res/AndroidManifest.xml
+@@ -2075,6 +2075,13 @@
+         android:description="@string/permdesc_getPackageSize"
+         android:protectionLevel="normal" />
+ 
++    <!-- @hide Allows an application to change the package signature as
++	 seen by applications -->
++    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
++        android:protectionLevel="dangerous"
++        android:label="@string/permlab_fakePackageSignature"
++        android:description="@string/permdesc_fakePackageSignature" />
++
+     <!-- @deprecated No longer useful, see
+          {@link android.content.pm.PackageManager#addPackageToPreferred}
+          for details. -->
+diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
+index 3613acf44aa..d1636c862c5 100644
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -1385,6 +1385,8 @@
+     <string-array name="config_locationProviderPackageNames" translatable="false">
+         <!-- The standard AOSP fused location provider -->
+         <item>com.android.location.fused</item>
++        <!-- The (faked) microg fused location provider (a free reimplementation) -->
++        <item>com.google.android.gms</item>
+     </string-array>
+ 
+     <!-- This string array can be overriden to enable test location providers initially. -->
+diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
+index 3eebe7eb68d..7405386cd49 100644
+--- a/core/res/res/values/strings.xml
++++ b/core/res/res/values/strings.xml
+@@ -764,6 +764,10 @@
+ 
+     <!--  Permissions -->
+ 
++    <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permlab_fakePackageSignature">Spoof package signature</string>
++    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permdesc_fakePackageSignature">Allows the app to pretend to be a different app. Malicious applications might be able to use this to access private application data. Legitimate uses include an emulator pretending to be what it emulates. Grant this permission with caution only!</string>
+     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permlab_statusBar">disable or modify status bar</string>
+     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+diff --git a/services/core/java/com/android/server/pm/PackageManagerService.java b/services/core/java/com/android/server/pm/PackageManagerService.java
+index f36b762c5e9..048a057d39c 100644
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -3571,8 +3571,9 @@ public class PackageManagerService extends IPackageManager.Stub
+             flags |= MATCH_ANY_USER;
+         }
+ 
+-        PackageInfo packageInfo = PackageParser.generatePackageInfo(p, gids, flags,
+-                ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId);
++        PackageInfo packageInfo = mayFakeSignature(p, PackageParser.generatePackageInfo(p, gids, flags,
++                ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId),
++                permissions);
+ 
+         if (packageInfo == null) {
+             return null;
+@@ -3584,6 +3585,24 @@ public class PackageManagerService extends IPackageManager.Stub
+         return packageInfo;
+     }
+ 
++    private PackageInfo mayFakeSignature(PackageParser.Package p, PackageInfo pi,
++            Set<String> permissions) {
++        try {
++            if (permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")
++                    && p.applicationInfo.targetSdkVersion > Build.VERSION_CODES.LOLLIPOP_MR1
++                    && p.mAppMetaData != null) {
++                String sig = p.mAppMetaData.getString("fake-signature");
++                if (sig != null) {
++                    pi.signatures = new Signature[] {new Signature(sig)};
++                }
++            }
++        } catch (Throwable t) {
++            // We should never die because of any failures, this is system code!
++            Log.w("PackageManagerService.FAKE_PACKAGE_SIGNATURE", t);
++	}
++        return pi;
++    }
++
+     @Override
+     public void checkPackageStartable(String packageName, int userId) {
+         final int callingUid = Binder.getCallingUid();


### PR DESCRIPTION
This is android_frameworks_base-N.patch rebased to the android-8.0.0_r4
tag.
It also expands the description a little to let the user know why a
legitimate app might request this permission.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>