### PR TITLE
Add patch for Android-O

### DIFF
--- a/patches/android_frameworks_base-O.patch
+++ b/patches/android_frameworks_base-O.patch
@@ -1,0 +1,89 @@
+diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
+index ea0e39c..a936983 100644
+--- a/core/res/AndroidManifest.xml
++++ b/core/res/AndroidManifest.xml
+@@ -2085,6 +2085,13 @@
+         android:description="@string/permdesc_getPackageSize"
+         android:protectionLevel="normal" />
+ 
++    <!-- @hide Allows an application to change the package signature as
++         seen by applications -->
++    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
++        android:protectionLevel="dangerous"
++        android:label="@string/permlab_fakePackageSignature"
++        android:description="@string/permdesc_fakePackageSignature" />
++
+     <!-- @deprecated No longer useful, see
+          {@link android.content.pm.PackageManager#addPackageToPreferred}
+          for details. -->
+diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
+index c7846cf..916d8a5 100644
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -1385,6 +1385,8 @@
+     <string-array name="config_locationProviderPackageNames" translatable="false">
+         <!-- The standard AOSP fused location provider -->
+         <item>com.android.location.fused</item>
++        <!-- The (faked) microg fused location provider -->
++        <item>com.google.android.gms</item>
+     </string-array>
+ 
+     <!-- This string array can be overriden to enable test location providers initially. -->
+diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
+index 58135db..e65367a 100644
+--- a/core/res/res/values/strings.xml
++++ b/core/res/res/values/strings.xml
+@@ -770,6 +770,11 @@
+     <!--  Permissions -->
+ 
+     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permlab_fakePackageSignature">Spoof package signature</string>
++    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permdesc_fakePackageSignature">Allows the app to pretend to be a different app. Malicious applications might be able to use this to access private application data. Grant this permission with caution only!</string>
++
++    <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permlab_statusBar">disable or modify status bar</string>
+     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permdesc_statusBar">Allows the app to disable the status bar or add and remove system icons.</string>
+
+diff --git a/PackageManagerService.java b/PackageManagerService.java
+index b455f62..c29f112 100644
+--- a/PackageManagerService.java
++++ b/PackageManagerService.java
+@@ -3571,9 +3571,9 @@ public class PackageManagerService extends IPackageManager.Stub
+             flags |= MATCH_ANY_USER;
+         }
+ 
+-        PackageInfo packageInfo = PackageParser.generatePackageInfo(p, gids, flags,
+-                ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId);
+-
++        PackageInfo packageInfo = mayFakeSignature(p, PackageParser.generatePackageInfo(p, gids, flags,
++											ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId),
++						   permissions);
+         if (packageInfo == null) {
+             return null;
+         }
+@@ -3584,6 +3584,23 @@ public class PackageManagerService extends IPackageManager.Stub
+         return packageInfo;
+     }
+ 
++    private PackageInfo mayFakeSignature(PackageParser.Package p, PackageInfo pi, Set<String> permissions) {
++	try {
++	    if (permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")
++		&& p.applicationInfo.targetSdkVersion > Build.VERSION_CODES.LOLLIPOP_MR1
++		&& p.mAppMetaData != null) {
++		String sig = p.mAppMetaData.getString("fake-signature");
++		if (sig != null) {
++		    pi.signatures = new Signature [] {new Signature(sig)};
++		}
++	    }
++	} catch (Throwable t) {
++	    // We should never die because of any failures, this is system code!
++	    Log.w("PackageManagerService.FAKE_PACKAGE_SIGNATURE", t);
++	}
++	return pi;
++    }
++
+     @Override
+     public void checkPackageStartable(String packageName, int userId) {
+         final int callingUid = Binder.getCallingUid();


### PR DESCRIPTION
Adds the necessary patch information to patch O to allow signature spoofing.