### PR TITLE
Bump com.google.android.gms (fixes #482 #526 #543)

### DIFF
--- a/play-services-core/build.gradle
+++ b/play-services-core/build.gradle
@@ -65,7 +65,7 @@ android {
         versionName getMyVersionName()
         def x = getMyVersionCode() - 367
         // We are not allowed to freely choose the hundreds column as it defines the device type
-        versionCode(12221400 + x % 100 + ((int) (x / 100)) * 1000)
+        versionCode(12688000 + x % 100 + ((int) (x / 100)) * 1000)
 
         minSdkVersion androidMinSdk()
         targetSdkVersion androidTargetSdk()


### PR DESCRIPTION
As far as I know, this is enough to make SafetyNet pass (as long as the correct droidguard VM is downloaded, which is only the case for ARMv7 devices).

Therefore, this should fix #482 (as well as the duplicates #526 and #543)