### PR TITLE
Temporarily fix broadcasts not being properly sent

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -476,7 +476,7 @@ public class McsService extends Service implements Handler.Callback {
                 logd("Target: " + resolveInfo);
                 Intent targetIntent = new Intent(intent);
                 targetIntent.setComponent(new ComponentName(resolveInfo.activityInfo.packageName, resolveInfo.activityInfo.name));
-                sendOrderedBroadcast(targetIntent, msg.category + ".permission.C2D_MESSAGE");
+                sendOrderedBroadcast(targetIntent, null);
             }
         }
     }


### PR DESCRIPTION
This allows apps without the *.permission.C2D_MESSAGE to receive the broadcast

This is an implementation of the fix described [here](https://github.com/microg/android_packages_apps_GmsCore/issues/259#issuecomment-270035886).

I have not tested this code and it may contain bugs or not work.  The motivation is to fix #444, #259, and potentially many other apps that do not use their package name as required by the GCM spec but that still work with the official Google implementation.

It should be considered a temporary fix since this completely removes the required permission rather than fixing it.  A more permanent solution might be to look for and save any permission matching `*.permission.C2D_MESSAGE` when the app is installed.  This could then be used later when a broadcast is sent.

Note: This may be a privacy or security risk as it allows any receiver to potentially consume the broadcast since the permission is no longer checked.