### PR TITLE
Fix SafetyNet default value

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/snet/SafetyNetPrefs.java
+++ b/play-services-core/src/main/java/org/microg/gms/snet/SafetyNetPrefs.java
@@ -88,6 +88,10 @@ public class SafetyNetPrefs implements SharedPreferences.OnSharedPreferenceChang
         return official;
     }
 
+    public boolean isThirdParty() {
+        return thirdParty;
+    }
+
     public String getServiceUrl() {
         if (official) return OFFICIAL_ATTEST_BASE_URL;
         return customUrl;

--- a/play-services-core/src/main/java/org/microg/gms/snet/SafetyNetPrefs.java
+++ b/play-services-core/src/main/java/org/microg/gms/snet/SafetyNetPrefs.java
@@ -57,7 +57,7 @@ public class SafetyNetPrefs implements SharedPreferences.OnSharedPreferenceChang
 
     public void update() {
         disabled = defaultPreferences.getBoolean(PREF_SNET_DISABLED, true);
-        official = defaultPreferences.getBoolean(PREF_SNET_OFFICIAL, true);
+        official = defaultPreferences.getBoolean(PREF_SNET_OFFICIAL, false);
         selfSigned = defaultPreferences.getBoolean(PREF_SNET_SELF_SIGNED, false);
         thirdParty = defaultPreferences.getBoolean(PREF_SNET_THIRD_PARTY, false);
         customUrl = defaultPreferences.getString(PREF_SNET_CUSTOM_URL, null);

--- a/play-services-core/src/main/java/org/microg/gms/ui/SettingsActivity.java
+++ b/play-services-core/src/main/java/org/microg/gms/ui/SettingsActivity.java
@@ -80,7 +80,22 @@ public class SettingsActivity extends AbstractDashboardActivity {
             } else {
                 findPreference(PREF_GCM).setSummary(R.string.abc_capital_off);
             }
-            findPreference(PREF_SNET).setSummary(SafetyNetPrefs.get(getContext()).isEnabled() ? R.string.service_status_enabled : R.string.service_status_disabled);
+
+            if (SafetyNetPrefs.get(getContext()).isEnabled()) {
+                String snet_info = "";
+
+                if (SafetyNetPrefs.get(getContext()).isOfficial()) {
+                    snet_info = getString(R.string.pref_snet_status_official_info);
+                } else if (SafetyNetPrefs.get(getContext()).isSelfSigned()) {
+                    snet_info = getString(R.string.pref_snet_status_self_signed_info);
+                } else if (SafetyNetPrefs.get(getContext()).isThirdParty()) {
+                    snet_info = getString(R.string.pref_snet_status_third_party_info);
+                }
+
+                findPreference(PREF_SNET).setSummary(getString(R.string.service_status_enabled) + " / " + snet_info);
+            } else {
+                findPreference(PREF_SNET).setSummary(R.string.service_status_disabled);
+            }
 
             Preferences unifiedNlPrefs = new Preferences(getContext());
             int backendCount = TextUtils.isEmpty(unifiedNlPrefs.getLocationBackends()) ? 0 :

--- a/play-services-core/src/main/res/values-de/strings.xml
+++ b/play-services-core/src/main/res/values-de/strings.xml
@@ -152,11 +152,14 @@ Dies kann einige Minuten dauern."</string>
 
     <string name="pref_snet_status_official_title">Offizielle Server nutzen</string>
     <string name="pref_snet_status_official_summary">Erfordert eine ungerootetes ROM und den microG DroidGuard Helper</string>
+    <string name="pref_snet_status_official_info">(offizieller Server)</string>
     <string name="pref_snet_status_third_party_title">Alternativen Server nutzen</string>
     <string name="pref_snet_status_third_party_summary">Alternative Server können auch SafetyNet-Anfragen beantworten, die nicht durch DroidGuard signiert wurden</string>
+    <string name="pref_snet_status_third_party_info">(Dritt-Server)</string>
     <string name="pref_snet_custom_url_title">Alternative Server URL</string>
     <string name="pref_snet_custom_url_summary">Vollständige URL des alternativen Servers der SafetyNet-Anfragen beantwortet</string>
     <string name="pref_snet_self_signed_title">Selbst signieren</string>
     <string name="pref_snet_self_signed_summary">Statt einen Server zu nutzen, die SafetyNet signature lokal mit einem eigens erstellten Zertifikat signieren. Die meisten Apps werden diese Signaturen nicht akzeptieren.</string>
+    <string name="pref_snet_status_self_signed_info">(selbst-signiertes Zertifikat)</string>
 
 </resources>

--- a/play-services-core/src/main/res/values-de/strings.xml
+++ b/play-services-core/src/main/res/values-de/strings.xml
@@ -152,14 +152,14 @@ Dies kann einige Minuten dauern."</string>
 
     <string name="pref_snet_status_official_title">Offizielle Server nutzen</string>
     <string name="pref_snet_status_official_summary">Erfordert eine ungerootetes ROM und den microG DroidGuard Helper</string>
-    <string name="pref_snet_status_official_info">(offizieller Server)</string>
+    <string name="pref_snet_status_official_info">offizieller Server</string>
     <string name="pref_snet_status_third_party_title">Alternativen Server nutzen</string>
     <string name="pref_snet_status_third_party_summary">Alternative Server können auch SafetyNet-Anfragen beantworten, die nicht durch DroidGuard signiert wurden</string>
-    <string name="pref_snet_status_third_party_info">(Dritt-Server)</string>
+    <string name="pref_snet_status_third_party_info">Dritt-Server</string>
     <string name="pref_snet_custom_url_title">Alternative Server URL</string>
     <string name="pref_snet_custom_url_summary">Vollständige URL des alternativen Servers der SafetyNet-Anfragen beantwortet</string>
     <string name="pref_snet_self_signed_title">Selbst signieren</string>
     <string name="pref_snet_self_signed_summary">Statt einen Server zu nutzen, die SafetyNet signature lokal mit einem eigens erstellten Zertifikat signieren. Die meisten Apps werden diese Signaturen nicht akzeptieren.</string>
-    <string name="pref_snet_status_self_signed_info">(selbst-signiertes Zertifikat)</string>
+    <string name="pref_snet_status_self_signed_info">selbst-signiertes Zertifikat</string>
 
 </resources>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -165,11 +165,14 @@ This can take a couple of minutes."</string>
 
     <string name="pref_snet_status_official_title">Use official server</string>
     <string name="pref_snet_status_official_summary">Requires an unrooted system and microG DroidGuard Helper installed</string>
+    <string name="pref_snet_status_official_info">(official server)</string>
     <string name="pref_snet_status_third_party_title">Use third-party server</string>
     <string name="pref_snet_status_third_party_summary">Third-party servers might be able to reply to SafetyNet requests without DroidGuard signature</string>
+    <string name="pref_snet_status_third_party_info">(third-party server)</string>
     <string name="pref_snet_custom_url_title">Custom server URL</string>
     <string name="pref_snet_custom_url_summary">Full URL of the third-party server answering SafetyNet attestation requests</string>
     <string name="pref_snet_self_signed_title">Use self-signed certificate</string>
     <string name="pref_snet_self_signed_summary">Instead of requesting a server, sign SafetyNet responses locally using a self-signed certificate. Most apps will refuse to use self-signed responses.</string>
+    <string name="pref_snet_status_self_signed_info">(self-signed certificate)</string>
 
 </resources>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -165,14 +165,14 @@ This can take a couple of minutes."</string>
 
     <string name="pref_snet_status_official_title">Use official server</string>
     <string name="pref_snet_status_official_summary">Requires an unrooted system and microG DroidGuard Helper installed</string>
-    <string name="pref_snet_status_official_info">(official server)</string>
+    <string name="pref_snet_status_official_info">official server</string>
     <string name="pref_snet_status_third_party_title">Use third-party server</string>
     <string name="pref_snet_status_third_party_summary">Third-party servers might be able to reply to SafetyNet requests without DroidGuard signature</string>
-    <string name="pref_snet_status_third_party_info">(third-party server)</string>
+    <string name="pref_snet_status_third_party_info">third-party server</string>
     <string name="pref_snet_custom_url_title">Custom server URL</string>
     <string name="pref_snet_custom_url_summary">Full URL of the third-party server answering SafetyNet attestation requests</string>
     <string name="pref_snet_self_signed_title">Use self-signed certificate</string>
     <string name="pref_snet_self_signed_summary">Instead of requesting a server, sign SafetyNet responses locally using a self-signed certificate. Most apps will refuse to use self-signed responses.</string>
-    <string name="pref_snet_status_self_signed_info">(self-signed certificate)</string>
+    <string name="pref_snet_status_self_signed_info">self-signed certificate</string>
 
 </resources>


### PR DESCRIPTION
After enabling SafetyNet, and if it was never enabled before, set the default Server value to `official`.

Current code leaves it ambigously unset, which is unexpected by the user.

Fixes issue #405 reported by @ale5000-git 