### PR TITLE
Add implementation of ProviderInstallerImpl

### DIFF
--- a/play-services-core/build.gradle
+++ b/play-services-core/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation project(':vtm-extras')
     implementation project(':vtm-jts')
     implementation project(':vtm-microg-theme')
+
+    compile 'org.conscrypt:conscrypt-android:2.0.0'
 }
 
 def execResult(...args) {

--- a/play-services-core/src/main/java/com/google/android/gms/common/security/ProviderInstallerImpl.java
+++ b/play-services-core/src/main/java/com/google/android/gms/common/security/ProviderInstallerImpl.java
@@ -18,9 +18,11 @@ package com.google.android.gms.common.security;
 
 import android.content.Context;
 import android.util.Log;
+import org.conscrypt.OpenSSLProvider;
+import java.security.Security;
 
 public class ProviderInstallerImpl {
     public static void insertProvider(Context context) {
-        Log.d("ProviderInstallerImpl", "yep, i should do something with Security here...");
+        Security.insertProviderAt(new OpenSSLProvider(), 1);
     }
 }


### PR DESCRIPTION
This is an implementation of the method `ProviderInstallerImpl` to help protect against SSL exploits.  A new dependency on conscrypt was added and it should be updated periodically.  Minimal testing was done on an unofficial build of CM13, but further testing is welcome.

Fixes #504 and fixes #72.

I tested Hangouts it no longer appears to crash on startup, even without the workaround https://github.com/microg/android_packages_apps_GmsCore/issues/72#issuecomment-303714674.

Issue #86 calls this code so it should probably be tested.  I have not tested Gmail Sync, but I suspect this only fixes one of multiple problems with it.

Other Google and non-Google apps may be affected as well if they attempted to [update the security provider](https://developer.android.com/training/articles/security-gms-provider).

Note: This is not a full implementation since a couple things are missing, but it seems to be enough to work.  For example, the default `HostnameVerifier` is not set, which I think Google added to prevent certain attack vectors.  Another thing missing is a test for the `conscrypt_gmscore_jni` version.  These should be added in the future for better security and stability.