### PR TITLE
Set package of intent prior to broadcasting

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -485,6 +485,7 @@ public class McsService extends Service implements Handler.Callback {
             for (ResolveInfo resolveInfo : infos) {
                 logd("Target: " + resolveInfo);
                 Intent targetIntent = new Intent(intent);
+                targetIntent.setPackage(msg.category);
                 targetIntent.setComponent(new ComponentName(resolveInfo.activityInfo.packageName, resolveInfo.activityInfo.name));
                 sendOrderedBroadcast(targetIntent, receiverPermission);
             }


### PR DESCRIPTION
This should prevent an intent from being broadcast to registered receivers that do not match the specified package.

This PR might prevent issues if one installed app causes [`receiverPermission` to be null](https://github.com/microg/android_packages_apps_GmsCore/blob/f94d140dea71ee5418aa94861931445f67b3968f/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java#L478) while another app does not use an [`IntentFilter`](https://developer.android.com/reference/android/content/IntentFilter).

From the documentation on [registerReceiver](https://developer.android.com/reference/android/content/Context#registerReceiver(android.content.BroadcastReceiver,%20android.content.IntentFilter)):
> As of `Build.VERSION_CODES.ICE_CREAM_SANDWICH`, receivers registered with this method will correctly respect the `Intent.setPackage(String)` specified for an Intent being broadcast. Prior to that, it would be ignored and delivered to all matching registered receivers. Be careful if using this for security.

This PR seems like a good addition after #572 (https://github.com/microg/android_packages_apps_GmsCore/commit/f94d140dea71ee5418aa94861931445f67b3968f).  With my minimal testing I have not seen this patch cause any regressions, but I have not seen it fix any problems either.  Further testing should be done before merging.