### PR TITLE
bump spoofed Play Services Version to 14.3.66

### DIFF
--- a/play-services-core/build.gradle
+++ b/play-services-core/build.gradle
@@ -46,7 +46,7 @@ def execResult(...args) {
     return stdout.toString().trim()
 }
 
-def gmsVersion = "13.2.80"
+def gmsVersion = "14.3.66"
 def gmsVersionCode = Integer.parseInt(gmsVersion.replaceAll('\\.', ''))
 def gitVersionBase = execResult('git', 'describe', '--tags', '--abbrev=0').substring(1)
 def gitCommitCount = Integer.parseInt(execResult('git', 'rev-list', '--count', "v$gitVersionBase..HEAD"))


### PR DESCRIPTION
Solves the 'updating Play Support libraries' nag (Play Services in disguise) and the caused mobile data drain users are experiencing when using official or patched Play Store due the current official release spoofing the older version 13.2.80.