### PR TITLE
Fix app unregistration in Android 8.0+ and prevent a crash

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -250,7 +250,8 @@
 
         <receiver android:name="org.microg.gms.gcm.UnregisterReceiver">
             <intent-filter>
-                <action android:name="android.intent.action.PACKAGE_ADDED"/>
+                <action android:name="android.intent.action.PACKAGE_DATA_CLEARED"/>
+                <action android:name="android.intent.action.PACKAGE_FULLY_REMOVED"/>
                 <action android:name="android.intent.action.PACKAGE_REMOVED"/>
 
                 <data android:scheme="package"/>

--- a/play-services-core/src/main/java/org/microg/gms/gcm/UnregisterReceiver.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/UnregisterReceiver.java
@@ -8,7 +8,10 @@ import android.util.Log;
 import java.util.List;
 
 import static android.content.Intent.ACTION_PACKAGE_REMOVED;
+import static android.content.Intent.ACTION_PACKAGE_DATA_CLEARED;
+import static android.content.Intent.ACTION_PACKAGE_FULLY_REMOVED;
 import static android.content.Intent.EXTRA_DATA_REMOVED;
+import static android.content.Intent.EXTRA_REPLACING;
 
 public class UnregisterReceiver extends BroadcastReceiver {
     private static final String TAG = "GmsGcmUnregisterRcvr";
@@ -16,10 +19,13 @@ public class UnregisterReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(final Context context, Intent intent) {
         Log.d(TAG, "Package changed: " + intent);
-        if (ACTION_PACKAGE_REMOVED.contains(intent.getAction()) && intent.getBooleanExtra(EXTRA_DATA_REMOVED, false)) {
+        if ((ACTION_PACKAGE_REMOVED.contains(intent.getAction()) && intent.getBooleanExtra(EXTRA_DATA_REMOVED, false) &&
+                !intent.getBooleanExtra(EXTRA_REPLACING, false)) ||
+                ACTION_PACKAGE_FULLY_REMOVED.contains(intent.getAction()) ||
+                ACTION_PACKAGE_DATA_CLEARED.contains(intent.getAction())) {
             final GcmDatabase database = new GcmDatabase(context);
             final String packageName = intent.getData().getSchemeSpecificPart();
-            Log.d(TAG, "Package removed: " + packageName);
+            Log.d(TAG, "Package removed or data cleared: " + packageName);
             final GcmDatabase.App app = database.getApp(packageName);
             if (app != null) {
                 new Thread(new Runnable() {

--- a/play-services-core/src/main/java/org/microg/gms/ui/GcmAppFragment.java
+++ b/play-services-core/src/main/java/org/microg/gms/ui/GcmAppFragment.java
@@ -99,6 +99,10 @@ public class GcmAppFragment extends ResourceSettingsFragment {
 
     private void updateAppDetails() {
         GcmDatabase.App app = database.getApp(packageName);
+        if (app == null) {
+            getActivity().finish();
+            return;
+        }
         PreferenceScreen root = getPreferenceScreen();
 
         SwitchPreference wakeForDelivery = (SwitchPreference) root.findPreference(PREF_WAKE_FOR_DELIVERY);


### PR DESCRIPTION
A crash occurs if the GCM settings of an app are viewed, the app is uninstalled, and then the settings are viewed again.

This can be replicated as follows:

* Install an app that uses GCM.
* Launch it once so it registers.
* Check app registration status in microG and also tap on it to open the settings page.
* Uninstall the app.
* Go back to microG, which should still be on the settings page for the uninstalled app.
* MicroG instantly crashes.

The crash would occur since the app no longer exists in the database, but the `updateAppDetails` method assumes it does and does not have a null check.

This PR will finish the `Activity` of the `GcmAppFragment` without updating the details if the app was uninstalled while microG was in the background.

In addition, this PR will fix unregistering an app from GCM on Android 8.0+.  Apps will now unregister when fully uninstalled or when their data is cleared.  This fixes #743.