### PR TITLE
Include GCM message ID in app message intent

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -459,6 +459,7 @@ public class McsService extends Service implements Handler.Callback {
         intent.setAction(ACTION_C2DM_RECEIVE);
         intent.setPackage(msg.category);
         intent.putExtra(EXTRA_FROM, msg.from);
+        intent.putExtra(EXTRA_MESSAGE_ID, msg.id);
         if (app.wakeForDelivery) {
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         } else {


### PR DESCRIPTION
This fixes a NullPointerException when receiving a notification in react-native apps, like Mattermost (https://github.com/mattermost/mattermost-mobile)

The used framework expects the message ID to be present in the app message intent, leading to a NullPointerException when it isn't:
Here is the check: https://github.com/wix/react-native-notifications/blob/master/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java#L66
This returns null: https://github.com/wix/react-native-notifications/blob/master/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java#L47
And finally, the NPE: https://github.com/wix/react-native-notifications/blob/master/android/src/main/java/com/wix/reactnativenotifications/gcm/FcmInstanceIdListenerService.java#L29