### PR TITLE
build.gradle improve gitVersionBase calculation

### DIFF
--- a/play-services-core/build.gradle
+++ b/play-services-core/build.gradle
@@ -50,7 +50,7 @@ def execResult(...args) {
 
 def gmsVersion = "13.2.80"
 def gmsVersionCode = Integer.parseInt(gmsVersion.replaceAll('\\.', ''))
-def gitVersionBase = execResult('git', 'describe', '--tags', '--abbrev=0').substring(1)
+def gitVersionBase = execResult('git', 'describe', '--tags', '--abbrev=0', '--match=v[0-9]*').substring(1)
 def gitCommitCount = Integer.parseInt(execResult('git', 'rev-list', '--count', "v$gitVersionBase..HEAD"))
 def gitCommitId = execResult('git', 'show-ref', '--abbrev=7', '--head', 'HEAD').split(' ')[0]
 def gitDirty = execResult('git', 'status', '--porcelain').size() > 0


### PR DESCRIPTION
Currently the most recent tag is taken into account when calculating gitVersionBase. While this works as advertised for upstream, which only has v[0-9]* release-tags, this may cause issues on forks (which may have other tags aswell).

This change in build.gradle should make the build system happy in both upstream and fork repos, by switching from `git describe --tags --abbrev=0` to `git tag --list 'v[0-9]*' --sort=-v:refname`.