### PR TITLE
new submodule: Phonesky patches for microG (in-)app-purchases support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "extern/RemoteDroidGuard"]
 	path = extern/RemoteDroidGuard
 	url = https://github.com/microg/android_packages_apps_RemoteDroidGuard.git
+[submodule "patches/Phonesky"]
+	path = patches/Phonesky
+	url = https://gitlab.com/Nanolx/microg-phonesky-iap-support.git


### PR DESCRIPTION
For a long while now I've been creating patches to Phonesky (and a self-signed apk build) which allows for (in-)app-purchases with microG on all ROMs. While there are Stock ROMs which don't need a patched Play Store, basically all AOSP/LOS based custom ROMs do.

Details on the reason why and the proposed solution here have already been discussed in #309 

This commits adds the Phonesky patches repository (I just created) as a new submodule.

Instructions are pretty straight-forward:

- download Phonesky from apkmirror (or the-like)
- `java -jar apktool.jar d <phonesky.apk>`
- `cd <phonesky>`
- `find . -type f -name '*.xml' | xargs sed '/APKTOOL_DUMMY/d' -i`
- `patch -Np1 -i <phonesky.diff>`
- `java -jar apktool.jar b <phonesky>`
- sign `<phonesky>/dist/<phonesky.apk>`

et voilá.

Initial Phonesky installations needs to be in `/system/priv-app`, required permission files are inside `etc/`.

I'm open for suggestions. If desired I can also add all older patches I've created to the repo, aswell.