### PR TITLE
Optimize some usage of reflection

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -54,6 +54,7 @@ import org.microg.gms.gcm.mcs.Setting;
 
 import java.io.Closeable;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -134,6 +135,10 @@ public class McsService extends Service implements Handler.Callback {
 
     private static int maxTtl = 24 * 60 * 60;
 
+    private Object deviceIdleController;
+    private Method getUserIdMethod;
+    private Method addPowerSaveTempWhitelistAppMethod;
+
     private class HandlerThread extends Thread {
 
         public HandlerThread() {
@@ -168,6 +173,22 @@ public class McsService extends Service implements Handler.Callback {
         heartbeatIntent = PendingIntent.getService(this, 0, new Intent(ACTION_HEARTBEAT, null, this, McsService.class), 0);
         alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
         powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            try {
+                Field field = Context.class.getField("DEVICE_IDLE_CONTROLLER");
+                IBinder binder = (IBinder) Class.forName("android.os.ServiceManager")
+                        .getMethod("getService", String.class).invoke(null, field.get(null));
+                if (binder != null) {
+                    deviceIdleController = Class.forName("android.os.IDeviceIdleController$Stub")
+                            .getMethod("asInterface", IBinder.class).invoke(null, binder);
+                    getUserIdMethod = UserHandle.class.getMethod("getUserId", int.class);
+                    addPowerSaveTempWhitelistAppMethod = deviceIdleController.getClass()
+                            .getMethod("addPowerSaveTempWhitelistApp", String.class, long.class, int.class, String.class);
+                }
+            } catch (Exception e) {
+                Log.w(TAG, e);
+            }
+        }
         synchronized (McsService.class) {
             if (handlerThread == null) {
                 handlerThread = new HandlerThread();
@@ -491,18 +512,10 @@ public class McsService extends Service implements Handler.Callback {
                 Intent targetIntent = new Intent(intent);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && app.wakeForDelivery) {
                     try {
-                        Field field = Context.class.getField("DEVICE_IDLE_CONTROLLER");
-                        IBinder binder = (IBinder) Class.forName("android.os.ServiceManager")
-                                .getMethod("getService", String.class).invoke(null, field.get(null));
-                        if (binder != null) {
-                            Object deviceIdleController = Class.forName("android.os.IDeviceIdleController$Stub")
-                                    .getMethod("asInterface", IBinder.class).invoke(null, binder);
-                            int userId = (int) UserHandle.class.getMethod("getUserId", int.class)
-                                    .invoke(null, getPackageManager().getApplicationInfo(packageName, 0).uid);
+                        if (getUserIdMethod != null && addPowerSaveTempWhitelistAppMethod != null && deviceIdleController != null) {
+                            int userId = (int) getUserIdMethod.invoke(null, getPackageManager().getApplicationInfo(packageName, 0).uid);
                             logd("Adding app " + packageName + " for userId " + userId + " to the temp whitelist");
-                            deviceIdleController.getClass()
-                                    .getMethod("addPowerSaveTempWhitelistApp", String.class, long.class, int.class, String.class)
-                                    .invoke(deviceIdleController, packageName, 10000, userId, "GCM Push");
+                            addPowerSaveTempWhitelistAppMethod.invoke(deviceIdleController, packageName, 10000, userId, "GCM Push");
                         }
                     } catch (Exception e) {
                         Log.w(TAG, e);


### PR DESCRIPTION
This will minimize the number of times certain expensive reflection calls are used by moving them from `handleAppMessage()` to `onCreate()`.

Based on the request by @ale5000-git https://github.com/microg/android_packages_apps_GmsCore/pull/732#issuecomment-485265795