### PR TITLE
Improve building into AOSP Pie ROM

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -34,6 +34,7 @@ $(gmscore_root)/$(gmscore_dir)/$(gmscore_apk):
 	cd $(gmscore_root)/$(gmscore_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform
+LOCAL_PRIVILEGED_MODULE := true
 LOCAL_SRC_FILES := $(gmscore_dir)/$(gmscore_apk)
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)

--- a/Android.mk
+++ b/Android.mk
@@ -21,17 +21,20 @@ LOCAL_PACKAGE_NAME := GmsCore
 
 gmscore_root  := $(LOCAL_PATH)
 gmscore_dir   := play-services-core
-gmscore_out   := $(TARGET_COMMON_OUT_ROOT)/obj/APPS/$(LOCAL_MODULE)_intermediates
+gmscore_out   := out/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
 gmscore_build := $(gmscore_root)/$(gmscore_dir)/build
 gmscore_apk   := build/outputs/apk/release/play-services-core-release-unsigned.apk
 
-$(gmscore_root)/$(gmscore_dir)/$(gmscore_apk):
-	rm -Rf $(gmscore_build)
-	mkdir -p $(ANDROID_BUILD_TOP)/$(gmscore_out)
-	ln -s $(ANDROID_BUILD_TOP)/$(gmscore_out) $(ANDROID_BUILD_TOP)/$(gmscore_build)
-	echo "sdk.dir=$(ANDROID_HOME)" > $(gmscore_root)/local.properties
-	cd $(gmscore_root) && git submodule update --recursive --init
-	cd $(gmscore_root)/$(gmscore_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
+.PHONY: preps_gms
+preps_gms:
+	rm -rf $(gmscore_build); \
+	mkdir -p $(gmscore_out); \
+	ln -s ../../../../$(gmscore_out) $(gmscore_build)
+
+$(gmscore_root)/$(gmscore_dir)/$(gmscore_apk): preps_gms
+	echo "sdk.dir=$(ANDROID_HOME)" > $(gmscore_root)/local.properties; \
+	cd $(gmscore_root) && git submodule update --recursive --init; \
+	cd $(gmscore_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := true

--- a/Android.mk
+++ b/Android.mk
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := privapp-permissions-com.google.android.gms.xml
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/permissions
+LOCAL_SRC_FILES := permissions/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := GmsCore
@@ -41,5 +50,6 @@ LOCAL_PRIVILEGED_MODULE := true
 LOCAL_SRC_FILES := $(gmscore_dir)/$(gmscore_apk)
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
+LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml
 
 include $(BUILD_PREBUILT)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 android.useDeprecatedNdk=true
+org.gradle.jvmargs=-Xmx1g

--- a/permissions/privapp-permissions-com.google.android.gms.xml
+++ b/permissions/privapp-permissions-com.google.android.gms.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <permissions>
+        <privapp-permissions package="com.google.android.gms">
+            <permission name="android.permission.FAKE_PACKAGE_SIGNATURE"/>
+            <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>
+            <permission name="android.permission.LOCATION_HARDWARE"/>
+            <permission name="android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST"/>
+        </privapp-permissions>
+    </permissions>

--- a/proguard.flags
+++ b/proguard.flags
@@ -1,3 +1,5 @@
+-dontwarn java.lang.invoke.StringConcatFactory
+
 # We use ProGuard for optimizations, obfuscation is for those who have sth to hide
 -dontobfuscate
 -optimizations !code/allocation/variable


### PR DESCRIPTION
Following commits improve building within a ROM as described on https://github.com/microg/android_packages_apps_GmsCore/wiki/Building

Depending on the ROM, there might be more changes needed (e.g. toolchain versions). However this are structural changes.
I tested this on Sony AOSP Pie.

Reasons for changes:
- 4b1aec8: GmsCore.apk should be in system/priv-app
- 2a2eacc: Removed ANDROID_BUILD_TOP as deprecated; Previous linking would not work with build on multiple threads
- 51a5ec3: Sony AOSP Pie ROM won't boot without the privapp-whitelisting, others seem to have same issue
- 3911c35: Newer gradle versions limit Heap to 512MB, however 1GB is needed
- ab34ef2: proguard warnings would break compile
