### PR TITLE
Make requestLocationSettingsDialog return success

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/location/GoogleLocationManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/location/GoogleLocationManagerServiceImpl.java
@@ -307,7 +307,7 @@ public class GoogleLocationManagerServiceImpl extends IGoogleLocationManagerServ
     public void requestLocationSettingsDialog(LocationSettingsRequest settingsRequest, ISettingsCallbacks callback, String packageName) throws RemoteException {
         Log.d(TAG, "requestLocationSettingsDialog: " + settingsRequest);
         PackageUtils.getAndCheckCallingPackage(context, packageName);
-        callback.onLocationSettingsResult(new LocationSettingsResult(new LocationSettingsStates(true, true, false, true, true, false), Status.CANCELED));
+        callback.onLocationSettingsResult(new LocationSettingsResult(new LocationSettingsStates(true, true, false, true, true, false), Status.SUCCESS));
     }
 
     @Override


### PR DESCRIPTION
This method gets a list of location methods an app wants to use, displays a dialog to the user whether to enable them and returns the result to the app, in theory.

The current implementation always returns "network location and GPS enabled, Bluetooth disabled", shows no dialog and returns CANCELLED.

This tips up some apps (eg. `com.tier.app` and  `com.runtastic.android`) and prevents them from accessing the location (also, they show no indication of an error which is not exactly great UX).

This small patch changes the result to SUCCESS which makes the Tier app work at least. (I didn't try Runtastic with this patch.)

A more thorough solution would require comparing the requested values and our fixed values and returning SUCCESS if they match (/ contain each other / overlap?), and [`SETTINGS_CHANGE_UNAVAILABLE` otherwise](https://github.com/microg/android_external_GmsApi/blob/ef0cfe1757e76a57f07b3a0ccb135949d3e78924/play-services-location-api/src/main/java/com/google/android/gms/location/LocationSettingsStatusCodes.java#L32).

(Or we could actually check the system settings and display a dialog, but that would be much more work.)