### PR TITLE
Fix improper apps not using C2D_MESSAGE permission

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -61,6 +61,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -529,6 +530,9 @@ public class McsService extends Service implements Handler.Callback {
         try {
             String name = packageName + ".permission.C2D_MESSAGE";
             getPackageManager().getPermissionInfo(name, 0);
+            if(!Arrays.asList(getPackageManager().getPackageInfo(packageName, PackageManager.GET_PERMISSIONS).requestedPermissions).contains(name)){
+                throw new PackageManager.NameNotFoundException(name);
+            }
             receiverPermission = name;
         } catch (PackageManager.NameNotFoundException e) {
             receiverPermission = null;


### PR DESCRIPTION
There can be cases with (poorly written?) apps that they declare the <code>packageName&nbsp;+&nbsp;".permission.C2D_MESSAGE"</code> permission but don't actually use it with the <code>\<uses&#8209;permission\></code> tag. 

That way they don't get the push notification just errors with 
```
Permission Denial: receiving Intent { act=com.google.android.c2dm.intent.RECEIVE flg=0x30
pkg=xxxxxxxxx cmp=xxxxxxxxx/com.google.firebase.iid.FirebaseInstanceIdReceiver
(has extras) } to xxxxxxxxx/com.google.firebase.iid.FirebaseInstanceIdReceiver
require xxxxxxxxx.permission.C2D_MESSAGE due to sender com.google.android.gms (uid 10131)
```

I hope this is a good way of solving it