### PR TITLE
Fix FCM registration for apps using firebase >= 20.1.1

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/common/PackageUtils.java
+++ b/play-services-core/src/main/java/org/microg/gms/common/PackageUtils.java
@@ -262,4 +262,12 @@ public class PackageUtils {
             return null;
         }
     }
+
+    public static int targetSdkVersion(Context context, String packageName) {
+        try {
+            return context.getPackageManager().getApplicationInfo(packageName, 0).targetSdkVersion;
+        } catch (PackageManager.NameNotFoundException e) {
+            return -1;
+        }
+    }
 }

--- a/play-services-core/src/main/java/org/microg/gms/gcm/PushRegisterHandler.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/PushRegisterHandler.java
@@ -145,7 +145,7 @@ class PushRegisterHandler extends Handler {
                         .checkin(LastCheckinInfo.read(context))
                         .app(packageName)
                         .delete(delete)
-                        .appid(subdata.getString("appid"), subdata.getString("gmp_app_id")),
+                        .extraParams(subdata),
                 bundle -> sendReply(what, id, replyTo, bundle));
     }
 }

--- a/play-services-core/src/main/java/org/microg/gms/gcm/PushRegisterManager.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/PushRegisterManager.java
@@ -70,12 +70,16 @@ public class PushRegisterManager {
 
     public static void completeRegisterRequest(Context context, GcmDatabase database, String requestId, RegisterRequest request, BundleCallback callback) {
         if (request.app != null) {
-            if (request.appSignature == null)
-                request.appSignature = PackageUtils.firstSignatureDigest(context, request.app);
             if (request.appVersion <= 0)
                 request.appVersion = PackageUtils.versionCode(context, request.app);
-            if (request.appVersionName == null)
-                request.appVersionName = PackageUtils.versionName(context, request.app);
+            if (!request.delete) {
+                if (request.appSignature == null) {
+                    request.appSignature = PackageUtils.firstSignatureDigest(context, request.app);
+                }
+                request.sdkVersion = PackageUtils.targetSdkVersion(context, request.app);
+                if (!request.hasExtraParam(GcmConstants.EXTRA_APP_VERSION_NAME))
+                    request.extraParam(GcmConstants.EXTRA_APP_VERSION_NAME, PackageUtils.versionName(context, request.app));
+            }
         }
 
         GcmDatabase.App app = database.getApp(request.app);

--- a/play-services-core/src/main/java/org/microg/gms/gcm/PushRegisterService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/PushRegisterService.java
@@ -20,7 +20,6 @@ import android.app.IntentService;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.IBinder;
 import android.os.Message;
@@ -139,7 +138,8 @@ public class PushRegisterService extends IntentService {
                         .build(Utils.getBuild(context))
                         .sender(intent.getStringExtra(EXTRA_SENDER))
                         .checkin(LastCheckinInfo.read(context))
-                        .app(packageName),
+                        .app(packageName)
+                        .extraParams(intent.getExtras()),
                 bundle -> {
                     Intent outIntent = new Intent(ACTION_C2DM_REGISTRATION);
                     outIntent.putExtras(bundle);
@@ -175,7 +175,8 @@ public class PushRegisterService extends IntentService {
                         .build(Utils.getBuild(this))
                         .sender(intent.getStringExtra(EXTRA_SENDER))
                         .checkin(LastCheckinInfo.read(this))
-                        .app(packageName),
+                        .app(packageName)
+                        .extraParams(intent.getExtras()),
                 bundle -> {
                     Intent outIntent = new Intent(ACTION_C2DM_REGISTRATION);
                     outIntent.putExtras(bundle);


### PR DESCRIPTION
With version 20.1.1 the Firebase Cloud Messaging SDK [started to use the Firebase Installations SDK](https://github.com/firebase/firebase-android-sdk/blob/208fee504642518792b97c892b77ed5eb1cf9882/firebase-installations/FCM_TOKENS_CHANGE.md), which affects the FCM registration process.
The implementation of FCM registration in microG failed to pass extra parameters that became relevant with the introduction of the Firebase Installations SDK to the FCM registration endpoint. These additional parameters are passed through to the endpoint with an 'X-' prefix.

Apps that use a version of the Firebase Cloud Messaging SDK >= 20.1.1 were unable to register with microG for push notifications, because the request to the FCM registration endpoint failed with the error code `FIS_AUTH_ERROR`.

First, I observed that Signal 4.61.6 failed to register with microG for push notifications. While it worked fine with Signal 4.60.9. After some debugging and searching on the internet, I found out that it's because Signal 4.61.1 uses a newer version of FCM (see signalapp/Signal-Android@c8dd4e5254c0771b2a1925df408ed9d360c68f84 and [#313](https://github.com/microg/android_packages_apps_GmsCore/issues/313#issuecomment-617651698)).

This pull request should fix #313 and #1068 (tested it myself).

For reference: Requests to the FCM registration endpoint (`https://android.clients.google.com/c2dm/register3`), which I captured while working on this issue.
<details>
  <summary>microG - Signal 4.61.6</summary>

### Request
| Header | |
| --- | --- |
| Content-Type | application/x-www-form-urlencoded |
| app | org.thoughtcrime.securesms |
| Authorization | AidLogin 4180318339633110089:3856385953474437405 |
| User-Agent | Android-GCM/1.3 (generic_x86_64 QP1A.190711.019) |
| Host | android.clients.google.com |
| Connection | Keep-Alive |
| Accept-Encoding | gzip |
| Content-Length | 328 |

| Parameter | |
| --- | --- |
| app | org.thoughtcrime.securesms |
| app_ver | 6473 |
| app_ver_name | 4.61.6 |
| appid | dfTUIjd0SBy9ib9GEkpTSQ |
| cert | 45989dc9ad8728c2aa9a82fa55503e34a8879374 |
| device | 4180318339633110089 |
| gmp_app_id | 1:312334754206:android:a9297b152879f266 |
| gmsv | 19420000 |
| osv | 29 |
| scope | * |
| sender | 312334754206 |
| subtype | 312334754206 |
| X-GOOG.USER_AID | 4180318339633110089 |

### Response
`Error=FIS_AUTH_ERROR`
</details>

<details>
  <summary>Google Apps - Signal 4.61.6</summary>

### Request
| Header | |
| --- | --- |
| Authorization | AidLogin 4109537073926052509:8941888930712902356 |
| app | org.thoughtcrime.securesms |
| gcm_ver | 200414023 |
| User-Agent | Android-GCM/1.5 (generic_x86_64 PSR1.180720.120) |
| content-length | 938 |
| content-type | application/x-www-form-urlencoded |
| Host | android.clients.google.com |
| Connection | Keep-Alive |
| Accept-Encoding | gzip |

| Parameter | |
| --- | --- |
| app | org.thoughtcrime.securesms |
| app_ver | 6473 |
| cert | 45989dc9ad8728c2aa9a82fa55503e34a8879374 |
| device | 4109537073926052509 |
| gcm_ver | 200414023 |
| info | MycplvjMe54VQEb1aBJ6XhwiPP1RKRc |
| plat | 0 |
| sender | 312334754206 |
| target_ver | 28 |
| X-app_ver | 6473 |
| X-app_ver_name | 4.61.6 |
| X-appid | eSLlghbbKSQ |
| X-cliv | fiid-20.2.0 |
| X-firebase-app-name-hash | R1dAH9Ui7M-ynoznwBdw01tLxhI |
| X-Firebase-Client | fire-installations/16.3.1 fire-core/19.3.0 fire-fcm/20.2.0 fire-iid/20.2.0 fire-android/ |
| X-Firebase-Client-Log-Type | 1 |
| X-gmp_app_id | 1:312334754206:android:a9297b152879f266 |
| X-gmsv | 200414023 |
| X-Goog-Firebase-Installations-Auth | eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaWQiOiJlU0xsZ2hiYktTUSIsInByb2plY3ROdW1iZXIiOjMxMjMzNDc1NDIwNiwiZXhwIjoxNTkyMjQ3ODgyLCJhcHBJZCI6IjE6MzEyMzM0NzU0MjA2OmFuZHJvaWQ6YTkyOTdiMTUyODc5ZjI2NiJ9.AB2LPV8wRgIhAJGvV7Gu7yaJmuvlaGxWH1ScLlasIWaEMIjMxRvxwYBDAiEAxDu0Eeh9iAiG8YyOrAtOo9OlbXfoGTCXK7yLumse9TY |
| X-osv | 28 |
| X-scope | * |
| X-subtype | 312334754206 |

### Response
`token=eSLlghbbKSQ:APA91bHUaHNvl-vv-m7flt86UEssQ4K1S2pJ5Rpyx4jQPTxeUbeq1UFDTMAEArRZ88zRcU60d0KAm8DDGjw1CLetH-UurduMl58wE4lySEhk-PIStp9xNl-QQymU-qY6ppNhn6ONGMsl`
</details>


<details>
  <summary>microG (fixed) - Signal 4.61.6</summary>

### Request
| Header | |
| --- | --- |
| Content-Type | application/x-www-form-urlencoded |
| app | org.thoughtcrime.securesms |
| Authorization | AidLogin 4180318339633110089:3856385953474437405 |
| User-Agent | Android-GCM/1.5 (generic_x86_64 QP1A.190711.019) |
| Host | android.clients.google.com |
| Connection | Keep-Alive |
| Accept-Encoding | gzip |
| Content-Length | 908 |

| Parameter | |
| --- | --- |
| app | org.thoughtcrime.securesms |
| app_ver | 6473 |
| cert | 45989dc9ad8728c2aa9a82fa55503e34a8879374 |
| device | 4180318339633110089 |
| sender | 312334754206 |
| target_ver | 29 |
| X-app_ver | 6473 |
| X-app_ver_name | 4.61.6 |
| X-appid | eiZ5JUbIQy2xhrVUUX74Vz |
| X-cliv | fiid-20.2.0 |
| X-firebase-app-name-hash | R1dAH9Ui7M-ynoznwBdw01tLxhI |
| X-Firebase-Client | fire-core/19.3.0 fire-installations/16.3.1 fire-fcm/20.2.0 fire-iid/20.2.0 fire-android/ |
| X-Firebase-Client-Log-Type | 1 |
| X-gmp_app_id | 1:312334754206:android:a9297b152879f266 |
| X-gmsv | 19420021 |
| X-Goog-Firebase-Installations-Auth | eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaWQiOiJlaVo1SlViSVF5MnhoclZVVVg3NFZ6IiwicHJvamVjdE51bWJlciI6MzEyMzM0NzU0MjA2LCJleHAiOjE1OTIyNjUwNzQsImFwcElkIjoiMTozMTIzMzQ3NTQyMDY6YW5kcm9pZDphOTI5N2IxNTI4NzlmMjY2In0.AB2LPV8wRQIgajO4ZlCDxV5xRKGXM7-FHX2fA5PnUYrFR_gciCUAWykCIQDBYoRHH6_AjLlJnftEVf8gPyZG8n8iGslPzTPlbKBCsg |
| X-osv | 29 |
| X-scope | * |
| X-subtype | 312334754206 |

### Response
``
</details>


<details>
  <summary>microG - Signal 4.60.9</summary>

### Request
| Header | |
| --- | --- |
| Content-Type | application/x-www-form-urlencoded |
| app | org.thoughtcrime.securesms |
| Authorization | AidLogin 4180318339633110089:3856385953474437405 |
| User-Agent | Android-GCM/1.3 (generic_x86_64 QP1A.190711.019) |
| Host | android.clients.google.com |
| Connection | Keep-Alive |
| Accept-Encoding | gzip |
| Content-Length | 317 |

| Parameter | |
| --- | --- |
| app | org.thoughtcrime.securesms |
| app_ver | 6403 |
| app_ver_name | 4.60.9 |
| appid | eJc4q01O6VE |
| cert | 45989dc9ad8728c2aa9a82fa55503e34a8879374 |
| device | 4180318339633110089 |
| gmp_app_id | 1:312334754206:android:a9297b152879f266 |
| gmsv | 19420000 |
| osv | 29 |
| scope | * |
| sender | 312334754206 |
| subtype | 312334754206 |
| X-GOOG.USER_AID | 4180318339633110089 |

### Response
`token=APA91bF7xWB7eKEw1T_nBSRzOaB5OowndBTNboDLIWo4XzNB5aZVb1fg25Iq__0X46ATwVC4IvNMGM8q0QKeZ7sQQqF_QfKxxbdREy30d7ZTjuk2kQniEfjDkUI1ZiUPC4tRVHBYzac-`
</details>

<details>
  <summary>Google Apps - Signal 4.60.9</summary>

### Request
| Header | |
| --- | --- |
| Authorization | AidLogin 4109537073926052509:8941888930712902356 |
| app | org.thoughtcrime.securesms |
| gcm_ver | 200414023 |
| User-Agent | Android-GCM/1.5 (generic_x86_64 PSR1.180720.120) |
| content-length | 408 |
| content-type | application/x-www-form-urlencoded |
| Host | android.clients.google.com |
| Connection | Keep-Alive |
| Accept-Encoding | gzip |

| Parameter | |
| --- | --- |
| app | org.thoughtcrime.securesms |
| app_ver | 6403 |
| cert | 45989dc9ad8728c2aa9a82fa55503e34a8879374 |
| device | 4109537073926052509 |
| gcm_ver | 200414023 |
| info | MycplvjMe54VQEb1aBJ6XhwiPP1RKRc |
| plat | 0 |
| sender | 312334754206 |
| target_ver | 28 |
| X-app_ver | 6403 |
| X-app_ver_name | 4.60.9 |
| X-appid | cn91oO9qM5k |
| X-cliv | fiid-12451000 |
| X-gmp_app_id | 1:312334754206:android:a9297b152879f266 |
| X-gmsv | 200414023 |
| X-osv | 28 |
| X-scope | * |
| X-subtype | 312334754206 |

### Response
`token=cn91oO9qM5k:APA91bFOEDxOSyX9A5Sgy6Gb192VvQXLNccuMAfymu1LTAluH95SYliIH9OY5RPkiTvrmKF3TmkWSYBFWV6nXPS6nV07Mgid5fTApxm2YJ4TkLGA6NjyB7qXp9AHvqSWr3CtDSXkFp_n`
</details>


<details>
  <summary>microG (fixed) - Signal 4.60.9</summary>

### Request
| Header | |
| --- | --- |
| Content-Type | application/x-www-form-urlencoded |
| app | org.thoughtcrime.securesms |
| Authorization | AidLogin 4180318339633110089:3856385953474437405 |
| User-Agent | Android-GCM/1.5 (generic_x86_64 QP1A.190711.019) |
| Host | android.clients.google.com |
| Connection | Keep-Alive |
| Accept-Encoding | gzip |
| Content-Length | 345 |

| Parameter | |
| --- | --- |
| app | org.thoughtcrime.securesms |
| app_ver | 6403 |
| cert | 45989dc9ad8728c2aa9a82fa55503e34a8879374 |
| device | 4180318339633110089 |
| sender | 312334754206 |
| target_ver | 28 |
| X-app_ver | 6403 |
| X-app_ver_name | 4.60.9 |
| X-appid | cxHTg_z2BiU |
| X-cliv | fiid-12451000 |
| X-gmp_app_id | 1:312334754206:android:a9297b152879f266 |
| X-gmsv | 19420021 |
| X-osv | 29 |
| X-scope | * |
| X-subtype | 312334754206 |

### Response
`token=cxHTg_z2BiU:APA91bF5WZY8adWVx4YZmDGlTY9_VWyiQhkRw2RlqpfLj1mTGf0NLtGvkeseWvxgTobSmGjwhDzCgSZGdQ1tyGxCeAXGO03py0f85A8w749GJqq67igNdBQ3VgcH8PyEF5dJR-jbg2rO`
</details>