### PR TITLE
PackageUtils: Add Google Pay India version

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/common/PackageUtils.java
+++ b/play-services-core/src/main/java/org/microg/gms/common/PackageUtils.java
@@ -64,6 +64,7 @@ public class PackageUtils {
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.village.boond", "48e7985b8f901df335b5d5223579c81618431c7b");
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.subscriptions.red", "de8304ace744ae4c4e05887a27a790815e610ff0");
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.meetings", "47a6936b733dbdb45d71997fbe1d610eca36b8bf");
+        KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.nbu.paisa.user", "80df78bb700f9172bc671779b017ddefefcbf552");
     }
 
     public static boolean isGooglePackage(Context context, String packageName) {


### PR DESCRIPTION
Adding Google Pay India version signature to known apps.

Relevant Logs:

```
06-25 00:32:21.215  8788  8806 D GmsServicesProvider: query caller=com.google.android.apps.nbu.paisa.user name=primes:shutdown_primes value=null
06-25 00:32:21.243  8788  8788 D GmsClearcutSvc: onBind: Intent { act=com.google.android.gms.clearcut.service.START pkg=com.google.android.gms }
06-25 00:32:21.295  8788  9116 D GmsAuthProvider: Call from com.google.android.apps.nbu.paisa.user
06-25 00:32:21.298  8788  9116 W GmsAuthProvider: Not granting extended access to [com.google.android.apps.nbu.paisa.user], signature: 80df78bb700f9172bc671779b017ddefefcbf552
06-25 00:32:21.299  8788  9116 E DatabaseUtils: Writing exception to parcel
06-25 00:32:21.299  8788  9116 E DatabaseUtils: java.lang.SecurityException: Access denied, missing GET_ACCOUNTS or EXTENDED_ACCESS permission
06-25 00:32:21.299  8788  9116 E DatabaseUtils: 	at org.microg.gms.auth.AccountContentProvider.call(Unknown Source:134)
06-25 00:32:21.299  8788  9116 E DatabaseUtils: 	at android.content.ContentProvider.call(ContentProvider.java:2152)
06-25 00:32:21.299  8788  9116 E DatabaseUtils: 	at android.content.ContentProvider$Transport.call(ContentProvider.java:477)
06-25 00:32:21.299  8788  9116 E DatabaseUtils: 	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:277)
06-25 00:32:21.299  8788  9116 E DatabaseUtils: 	at android.os.Binder.execTransactInternal(Binder.java:1021)
06-25 00:32:21.299  8788  9116 E DatabaseUtils: 	at android.os.Binder.execTransact(Binder.java:994)
```