### PR TITLE
Fix GCM heartbeat interval for roaming connections with manual interval

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/gcm/GcmPrefs.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/GcmPrefs.java
@@ -114,7 +114,7 @@ public class GcmPrefs implements SharedPreferences.OnSharedPreferenceChangeListe
 
     public int getHeartbeatMsFor(String pref, boolean rawRoaming) {
         if (PREF_NETWORK_ROAMING.equals(pref) && (rawRoaming || networkRoaming != 0)) {
-            return networkRoaming * 6000;
+            return networkRoaming * 60000;
         } else if (PREF_NETWORK_MOBILE.equals(pref)) {
             if (networkMobile != 0) return networkMobile * 60000;
             else return learntMobile;


### PR DESCRIPTION
When using GCM on a roaming connection, the heartbeat interval is set
to: `networkRoaming  * 6000`. It should instead be
`networkRoaming * 60000` because we're converting from a number of
minutes (stored in the properties) to a number of milliseconds, like
it's done for regular mobile and wifi connections.