### PR TITLE
Exposure notifications - reading from the stream in a loop

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
@@ -159,7 +159,15 @@ class ExposureNotificationServiceImpl(private val context: Context, private val 
                             val entry = stream.nextEntry ?: break
                             if (entry.name == "export.bin") {
                                 val prefix = ByteArray(16)
-                                if (stream.read(prefix) == prefix.size && String(prefix).trim() == "EK Export v1") {
+                                var totalBytesRead = 0
+                                var bytesRead = 0
+                                while (bytesRead != -1 && totalBytesRead < prefix.size) {
+                                    bytesRead = stream.read(prefix, totalBytesRead, prefix.size - totalBytesRead)
+                                    if (bytesRead > 0) {
+                                        totalBytesRead += bytesRead
+                                    }
+                                }
+                                if (totalBytesRead == prefix.size && String(prefix).trim() == "EK Export v1") {
                                     val fileKeys = storeDiagnosisKeyExport(params.token, TemporaryExposureKeyExport.ADAPTER.decode(stream))
                                     keys + fileKeys
                                 } else {


### PR DESCRIPTION
Hi, `stream.read(byte[] buffer)` does not make an effort to read exactly `buffer.size` bytes, it just tries to read at least 1 byte, and may return with a smaller number of bytes read:

https://docs.oracle.com/javase/7/docs/api/java/util/zip/ZipInputStream.html#read(byte[],%20int,%20int)

This was a bug also present in original Google implementation, which resulted in header validation error on some devices.