### PR TITLE
Fix for #1120

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/checkin/CheckinClient.java
+++ b/play-services-core/src/main/java/org/microg/gms/checkin/CheckinClient.java
@@ -45,6 +45,7 @@ import java.util.zip.GZIPOutputStream;
 
 public class CheckinClient {
     private static final String TAG = "GmsCheckinClient";
+    private static final Object TODO = null; // TODO
     private static final List<String> TODO_LIST_STRING = new ArrayList<String>(); // TODO
     private static final List<CheckinRequest.Checkin.Statistic> TODO_LIST_CHECKIN = new ArrayList<CheckinRequest.Checkin.Statistic>(); // TODO
     private static final String SERVICE_URL = "https://android.clients.google.com/checkin";

--- a/play-services-core/src/main/java/org/microg/gms/checkin/CheckinClient.java
+++ b/play-services-core/src/main/java/org/microg/gms/checkin/CheckinClient.java
@@ -45,7 +45,8 @@ import java.util.zip.GZIPOutputStream;
 
 public class CheckinClient {
     private static final String TAG = "GmsCheckinClient";
-    private static final Object TODO = null; // TODO
+    private static final List<String> TODO_LIST_STRING = new ArrayList<String>(); // TODO
+    private static final List<CheckinRequest.Checkin.Statistic> TODO_LIST_CHECKIN = new ArrayList<CheckinRequest.Checkin.Statistic>(); // TODO
     private static final String SERVICE_URL = "https://android.clients.google.com/checkin";
 
     public static CheckinResponse request(CheckinRequest request) throws IOException {
@@ -108,10 +109,10 @@ public class CheckinClient {
                                 .timeMs(new Date().getTime())
                                 .build()))
                         .lastCheckinMs(checkinInfo.lastCheckin)
-                        .requestedGroup((List<String>) TODO)
+                        .requestedGroup(TODO_LIST_STRING)
                         .roaming(phoneInfo.roaming)
                         .simOperator(phoneInfo.simOperator)
-                        .stat((List<CheckinRequest.Checkin.Statistic>) TODO)
+                        .stat(TODO_LIST_CHECKIN)
                         .userNumber(0)
                         .build())
                 .deviceConfiguration(new CheckinRequest.DeviceConfig.Builder()


### PR DESCRIPTION
Actually instantiate objects so that we don't pass `null`. Fixes #1120.