### PR TITLE
Don't require apps to use com.google.android.c2dm.permission.RECEIVE permission for GCM/FCM

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -214,8 +214,7 @@
 
         <!-- Cloud Messaging -->
         <service
-            android:name="org.microg.gms.gcm.PushRegisterService"
-            android:permission="com.google.android.c2dm.permission.RECEIVE">
+            android:name="org.microg.gms.gcm.PushRegisterService">
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.REGISTER" />
                 <action android:name="com.google.android.c2dm.intent.UNREGISTER" />
@@ -233,8 +232,7 @@
         <service android:name="org.microg.gms.gcm.McsService" />
 
         <receiver
-            android:name="org.microg.gms.gcm.SendReceiver"
-            android:permission="com.google.android.c2dm.permission.RECEIVE">
+            android:name="org.microg.gms.gcm.SendReceiver">
             <intent-filter>
                 <action android:name="com.google.android.gcm.intent.SEND" />
             </intent-filter>


### PR DESCRIPTION
This PR allows apps to use and register to FCM without having to add `com.google.android.c2dm.permission.RECEIVE` permission in their manifest.
That's because this permission is not required anymore by FCM (see this [official migration guide from GCM to FCM, minute 3:15](https://youtu.be/IeexEiFprY8?t=196)) and causes apps that don't use it to crash (e.g. Google Earth amongst others).

This should fix #1113, fix #939, fix #918 and fix #866.

Note: I haven't tested this PR on a device due to a lack of time. I've just checked that the code builds successfully.