### PR TITLE
Added missing parcel field 8 for polylineoptions. Added gradle compile time option for selecting Mapbox map style.

### DIFF
--- a/play-services-api/src/main/java/com/google/android/gms/maps/model/PolylineOptions.java
+++ b/play-services-api/src/main/java/com/google/android/gms/maps/model/PolylineOptions.java
@@ -45,6 +45,8 @@ public class PolylineOptions extends AutoSafeParcelable {
     private boolean visible = true;
     @SafeParceled(7)
     private boolean geodesic = false;
+    @SafeParceled(8)
+    private boolean clickable = false;
 
     public PolylineOptions() {
     }
@@ -102,8 +104,17 @@ public class PolylineOptions extends AutoSafeParcelable {
         return visible;
     }
 
+    public boolean isClickable() {
+        return clickable;
+    }
+
     public PolylineOptions visible(boolean visible) {
         this.visible = visible;
+        return this;
+    }
+
+    public PolylineOptions clickable(boolean clickable) {
+        this.clickable = clickable;
         return this;
     }
 

--- a/play-services-maps-core-mapbox/build.gradle
+++ b/play-services-maps-core-mapbox/build.gradle
@@ -53,6 +53,11 @@ android {
         minSdkVersion androidMinSdk
         targetSdkVersion androidTargetSdk
         buildConfigField "String", "MAPBOX_KEY", "\"${mapboxKey()}\""
+        buildConfigField "boolean", "useMapboxStyle", "true"
+        buildConfigField "String", "MAPBOX_STYLE_SATELLITE_URI", "\"\""
+        buildConfigField "String", "MAPBOX_STYLE_SATELLITE_STREETS_URI", "\"\""
+        buildConfigField "String", "MAPBOX_STYLE_STREETS_URI", "\"\""
+        buildConfigField "String", "MAPBOX_STYLE_TERRAIN_URI", "\"\""
 
         ndk {
             abiFilters "armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64"

--- a/play-services-maps-core-mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps-core-mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -51,6 +51,7 @@ import com.mapbox.mapboxsdk.utils.ColorUtils
 import com.mapbox.mapboxsdk.utils.ThreadUtils
 import org.microg.gms.kotlin.unwrap
 import org.microg.gms.maps.MapsConstants.*
+import org.microg.gms.maps.mapbox.BuildConfig.*
 import org.microg.gms.maps.mapbox.model.*
 import org.microg.gms.maps.mapbox.utils.MapContext
 import org.microg.gms.maps.mapbox.utils.MultiArchLoader
@@ -348,16 +349,35 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
         }
 
         // TODO: Serve map styles locally
-        when (storedMapType) {
-            MAP_TYPE_SATELLITE -> map?.setStyle(Style.Builder().fromUrl("mapbox://styles/microg/cjxgloted25ap1ct4uex7m6hi"), update)
-            MAP_TYPE_TERRAIN -> map?.setStyle(Style.OUTDOORS, update)
-            MAP_TYPE_HYBRID -> map?.setStyle(Style.Builder().fromUrl("mapbox://styles/microg/cjxgloted25ap1ct4uex7m6hi"), update)
-            //MAP_TYPE_NONE, MAP_TYPE_NORMAL,
-            else -> map?.setStyle(Style.Builder().fromUrl("mapbox://styles/microg/cjui4020201oo1fmca7yuwbor"), update)
+        if (BuildConfig.useMapboxStyle) {
+            if (!BuildConfig.MAPBOX_STYLE_SATELLITE_URI.isEmpty() &&
+                    !BuildConfig.MAPBOX_STYLE_SATELLITE_STREETS_URI.isEmpty() &&
+                    !BuildConfig.MAPBOX_STYLE_STREETS_URI.isEmpty() &&
+                    !BuildConfig.MAPBOX_STYLE_TERRAIN_URI.isEmpty()) {
+                when (storedMapType) {
+                    MAP_TYPE_SATELLITE -> map?.setStyle(Style.Builder().fromUri(MAPBOX_STYLE_SATELLITE_URI), update)
+                    MAP_TYPE_TERRAIN -> map?.setStyle(Style.Builder().fromUri(MAPBOX_STYLE_TERRAIN_URI), update)
+                    MAP_TYPE_HYBRID -> map?.setStyle(Style.Builder().fromUri(MAPBOX_STYLE_SATELLITE_STREETS_URI), update)
+                    else -> map?.setStyle(Style.Builder().fromUri(MAPBOX_STYLE_STREETS_URI), update)
+                }
+            } else {
+                when (storedMapType) {
+                    MAP_TYPE_SATELLITE -> map?.setStyle(Style.SATELLITE, update)
+                    MAP_TYPE_TERRAIN -> map?.setStyle(Style.OUTDOORS, update)
+                    MAP_TYPE_HYBRID -> map?.setStyle(Style.SATELLITE_STREETS, update)
+                    else -> map?.setStyle(Style.MAPBOX_STREETS, update)
+                }
+            }
+        } else {
+            when (storedMapType) {
+                MAP_TYPE_SATELLITE -> map?.setStyle(Style.Builder().fromUrl("mapbox://styles/microg/cjxgloted25ap1ct4uex7m6hi"), update)
+                MAP_TYPE_TERRAIN -> map?.setStyle(Style.OUTDOORS, update)
+                MAP_TYPE_HYBRID -> map?.setStyle(Style.Builder().fromUrl("mapbox://styles/microg/cjxgloted25ap1ct4uex7m6hi"), update)
+                else -> map?.setStyle(Style.Builder().fromUrl("mapbox://styles/microg/cjui4020201oo1fmca7yuwbor"), update)
+            }
         }
 
         map?.let { BitmapDescriptorFactoryImpl.registerMap(it) }
-
     }
 
     override fun setWatermarkEnabled(watermark: Boolean) {
@@ -440,12 +460,10 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
 
     override fun setOnInfoWindowClickListener(listener: IOnInfoWindowClickListener?) {
         Log.d(TAG, "unimplemented Method: setOnInfoWindowClickListener")
-
     }
 
     override fun setInfoWindowAdapter(adapter: IInfoWindowAdapter?) {
         Log.d(TAG, "unimplemented Method: setInfoWindowAdapter")
-
     }
 
     override fun getTestingHelper(): IObjectWrapper? {


### PR DESCRIPTION
Was having issues with various apps and especially with com.trusty.ty.satellite (satellite tracking app) where the app would only show a white area. After debugging and playing with logcat i found it was failing with the hardcoded styles since i was using my own token key i did not have them available to me. So i added a BuildConfig switch to toggle between default hardcoded ones, the default Mapbox styles, or adding the Uri for a custom style.  The app was also complaining about field 8 for PolylineOptions being unknown so added that in as well. The app still doesn't work with markers showing their information but i guess that's a future battle.




