### PR TITLE
EN: enable onDowngrade() method

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
@@ -42,6 +42,10 @@ class ExposureDatabase private constructor(private val context: Context) : SQLit
         onUpgrade(db, 0, DB_VERSION)
     }
 
+    override fun onDowngrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        db.setVersion(oldVersion)
+    }
+
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
         if (oldVersion < 1) {
             db.execSQL("CREATE TABLE IF NOT EXISTS $TABLE_ADVERTISEMENTS(rpi BLOB NOT NULL, aem BLOB NOT NULL, timestamp INTEGER NOT NULL, rssi INTEGER NOT NULL, duration INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(rpi, timestamp));")


### PR DESCRIPTION
In case the database needs to be downgraded,
the onDowngrade() method is called.
SQLiteOpenHelper makes it possible to implement
this method, but it is not required to implement it.
However, downgrades seem to be necessary,
therefore onDowngrade() should be implemented


Logcat: 
android.database.sqlite.SQLiteException: Can't downgrade database from version 2 to 1
       at android.database.sqlite.SQLiteOpenHelper.onDowngrade(SQLiteOpenHelper.java:541)
       at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:415)
       at android.database.sqlite.SQLiteOpenHelper.getReadableDatabase(SQLiteOpenHelper.java:341)
       at org.microg.gms.nearby.exposurenotification.ExposureDatabase.<init>(ExposureDatabase.kt:334)
       at org.microg.gms.nearby.exposurenotification.ExposureDatabase.<init>(ExposureDatabase.kt:27)
       at org.microg.gms.nearby.exposurenotification.ExposureDatabase$Companion.ref(ExposureDatabase.kt:479)
       at org.microg.gms.nearby.exposurenotification.ExposureDatabase$Companion.with(ExposureDatabase.kt:485)
       at org.microg.gms.ui.ExposureNotificationsPreferencesFragment$updateContent$1$1.invokeSuspend(ExposureNotificationsPreferencesFragment.kt:76)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)

I'm unsure, if changes done in onUpgrade needs to be reverted when downgrading. Just setting the old version seems to work for me.