### PR TITLE
EN: using scanning loop instead of continuous scanning

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/Constants.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/Constants.kt
@@ -11,6 +11,10 @@ import java.util.*
 const val TAG = "ExposureNotification"
 val SERVICE_UUID = ParcelUuid(UUID.fromString("0000FD6F-0000-1000-8000-00805F9B34FB"))
 
+const val SCANNING_INTERVAL = 5 * 60
+const val SCANNING_INTERVAL_MS = SCANNING_INTERVAL * 1000
+const val SCANNING_TIME = 20 // Google uses 4s + 13s (if Bluetooth is used by something else)
+const val SCANNING_TIME_MS = SCANNING_TIME * 1000
 const val ROLLING_WINDOW_LENGTH = 10 * 60
 const val ROLLING_WINDOW_LENGTH_MS = ROLLING_WINDOW_LENGTH * 1000
 const val ROLLING_PERIOD = 144


### PR DESCRIPTION
* converting ScannerService to a lifecycleService
* running a simple loop starting / stopping the bluetooth scanner
* introducing SCANNING_INTERVAL as a constant for the loop period
* introducing SCANNING_TIME as a constant for the scanning duration per loop run

This is my first time using kotlin and I am also not very experienced programming for Android, so I probably did a lot of mistakes. I basically used the same concepts of the `AdvertiserService` for the `ScannerService`. The `AdvertiserService` class has a `suspendCoroutine`. I am not exactly sure for what it is used and did not include it in the `ScannerService`. I am also not sure if `ScannerService` needs the `onBind` function?

Probably there are many smarter ways of implementing it, so feel free to ignore it or redo it later on. With theses changes the EN API gets closer to the Google/Apple concept and it also solves #1158 for me. In case you want to stick to continuous scanning, you can set `SCANNING_TIME = SCANNING_INTERVAL` and still solve   #1158.

