### PR TITLE
Mapbox: Fix crash when destroying maps

### DIFF
--- a/play-services-maps-core-mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps-core-mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -402,7 +402,7 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
         return null
     }
 
-    override fun setLocationSource(locationSource: ILocationSourceDelegate) {
+    override fun setLocationSource(locationSource: ILocationSourceDelegate?) {
         Log.d(TAG, "unimplemented Method: setLocationSource")
     }
 


### PR DESCRIPTION
'setLocationSource' may be called with a null parameter:

E AndroidRuntime: Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter locationSource
E AndroidRuntime: at org.microg.gms.maps.mapbox.GoogleMapImpl.setLocationSource(Unknown Source:2)